### PR TITLE
Fix link to documentation references

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -1,5 +1,5 @@
 # Resources
 
 - [Learning resources](learning-resources.md)
-- [Documentation references](doc-references__.md)
+- [Documentation references](doc-references.md)
 - [Past work](past-work.md)


### PR DESCRIPTION
Closes #2 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a broken hyperlink in the documentation sidebar so the “Documentation references” link now navigates correctly, reducing 404 errors.
* **Documentation**
  * Updated the sidebar to point to the correct “Documentation references” page, improving navigation and access to reference materials. No other changes were made to the Resources section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->